### PR TITLE
fix r10k pkg installation

### DIFF
--- a/modules-profiles/service/manifests/puppet/master.pp
+++ b/modules-profiles/service/manifests/puppet/master.pp
@@ -1,8 +1,8 @@
 class service::puppet::master {
   class { 'r10k':
-    package_name              => 'rubygem-r10k',
-    version                   => '1.4.0',
-    install_options           => {'--from' => 'systemsmanagement:puppet'},
+    package_name              => 'ruby2.1-rubygem-r10k',
+    version                   => latest,
+    install_options           => ['--no-recommends', {'--from' => 'sysmgmt:puppet'}],
     remote                    => 'git://github.com/fork-bomb/puppet',
     provider                  => 'zypper',
     configfile                => '/etc/puppet/r10k.yaml',


### PR DESCRIPTION
Just rubygem-r10k or r10k didn't work, need to specify ruby2.1-rubygem-r10k
Also use 'latest' as version, alternatively we can put $version-$revision. Just
version is not sufficient, puppet tries to reinstall every time because
$version is different from $version-$revision (eg 1.4.0-5.1 vs 1.4.0)
Lastly, add --no-recommends in install_options, as it does not properly get
inherited by config.pp, and fix the --from repository name